### PR TITLE
Some fixes

### DIFF
--- a/src/ElectionVoteRepository.php
+++ b/src/ElectionVoteRepository.php
@@ -55,6 +55,10 @@ class ElectionVoteRepository extends ElectionVoteLoader {
 					function ($candidateId) use ($votes, $numCandidates) { 
 						if (!array_key_exists($candidateId, $votes))
 							return false;
+						$vote = $votes[$candidateId];
+						// 0.1, 01, 1e0, etc...
+						if (!ctype_digit($vote) || strval(intval($vote)) !== $vote)
+							return false;
 						
 						if ($votes[$candidateId] < 1 || $votes[$candidateId] > $numCandidates)
 							return false;

--- a/src/ElectionVoteRepository.php
+++ b/src/ElectionVoteRepository.php
@@ -72,7 +72,7 @@ class ElectionVoteRepository extends ElectionVoteLoader {
 	}
 	
 	function addVotes(User $user, array $votes) : ?string {
-		global $wgElectionMinRegistrationDate;
+		global $wgElectionActive, $wgElectionMinRegistrationDate;
 		
 		$this->db->startAtomic(__METHOD__);
 		
@@ -80,6 +80,10 @@ class ElectionVoteRepository extends ElectionVoteLoader {
 			$validationError = $this->validateVotes($votes);
 			if ($validationError) {
 				return $validationError;
+			}
+			
+			if (!$wgElectionActive) {
+				return 'There is no election.';
 			}
 			
 			if ($user->getBlock()) {

--- a/src/SpecialElectionResults.php
+++ b/src/SpecialElectionResults.php
@@ -10,6 +10,8 @@ class SpecialElectionResults extends SpecialPage {
 		$output = $this->getOutput();
 		$output->setPageTitle('Election results');
 		
+		$this->checkPermissions();
+		
 		$voteLoader = new ElectionVoteLoader(__METHOD__, $wgElectionId);
 		$results = $voteLoader->getResults($wgElectionCandidates);
 		

--- a/src/SpecialElectionResults.php
+++ b/src/SpecialElectionResults.php
@@ -8,6 +8,7 @@ class SpecialElectionResults extends SpecialPage {
 		global $wgElectionActive, $wgElectionId, $wgElectionCandidates;
 		
 		$output = $this->getOutput();
+		$output->setPageTitle('Election results');
 		
 		$voteLoader = new ElectionVoteLoader(__METHOD__, $wgElectionId);
 		$results = $voteLoader->getResults($wgElectionCandidates);

--- a/src/SpecialElectionResults.php
+++ b/src/SpecialElectionResults.php
@@ -15,6 +15,11 @@ class SpecialElectionResults extends SpecialPage {
 		$voteLoader = new ElectionVoteLoader(__METHOD__, $wgElectionId);
 		$results = $voteLoader->getResults($wgElectionCandidates);
 		
+		if (empty($results)) {
+			$output->addHTML('There are no votes to display.');
+			return;
+		}
+		
 		$output->addHTML(Html::openElement('table'));
 		foreach ($results as $candidate => $score) {
 			$output->addHTML(Html::openElement('tr'));

--- a/src/SpecialVote.php
+++ b/src/SpecialVote.php
@@ -20,7 +20,8 @@ class SpecialVote extends SpecialPage {
 		$message = $voteRepo->addVotes($this->getUser(), $votes);
 		
 		if ($message) {
-			echo $message; die;
+			$output->addHTML($message);
+			return;
 		}
 		
 		$output->addHTML('Thank you for voting');

--- a/src/SpecialVote.php
+++ b/src/SpecialVote.php
@@ -62,7 +62,11 @@ class SpecialVote extends SpecialPage {
 				
 		$numCandidates = sizeof($wgElectionCandidates);
 		
-		$output->addHTML(Html::openElement('form', ['method' => 'post', 'enctype' => 'multipart/form-data', 'action' => ''])); // TODO: get the action right
+		$output->addHTML(Html::openElement('form', [
+			'method' => 'post',
+			'enctype' => 'multipart/form-data',
+			'action' => SpecialPage::getTitleFor('Vote')->getFullURL()
+		]));
 		
 		$output->addHTML(Html::openElement('table'));
 		

--- a/src/SpecialVote.php
+++ b/src/SpecialVote.php
@@ -64,7 +64,13 @@ class SpecialVote extends SpecialPage {
 		$output->addHTML(Html::openElement('tr'));
 		$output->addHTML(Html::element('th', ['scope' => 'row']));
 		for ($rankIdx = 1; $rankIdx <= $numCandidates; $rankIdx++) {
-			$output->addHTML(Html::element('th', ['scope' => 'col'], $rankIdx));
+			$colHeader = $rankIdx;
+			if ($rankIdx === 1) {
+				$colHeader = "$rankIdx (most preferred)";
+			} elseif ($rankIdx === $numCandidates) {
+				$colHeader = "$rankIdx (least preferred)";
+			}
+			$output->addHTML(Html::element('th', ['scope' => 'col'], $colHeader));
 		}
 		$output->addHTML(Html::closeElement('tr'));
 		

--- a/src/SpecialVote.php
+++ b/src/SpecialVote.php
@@ -127,6 +127,7 @@ class SpecialVote extends SpecialPage {
 		$request = $this->getRequest();
 		$this->getOutput()->setPageTitle('Vote');
 		$this->checkPermissions();
+		$this->checkReadOnly();
 		
 		if ($request->wasPosted()) {
 			$this->handleVoteSubmission();

--- a/src/SpecialVote.php
+++ b/src/SpecialVote.php
@@ -110,6 +110,7 @@ class SpecialVote extends SpecialPage {
 	
 	function execute($par) {
 		$request = $this->getRequest();
+		$this->getOutput()->setPageTitle('Vote');
 		
 		if ($request->wasPosted()) {
 			$this->handleVoteSubmission();

--- a/src/SpecialVote.php
+++ b/src/SpecialVote.php
@@ -1,7 +1,7 @@
 <?php
 class SpecialVote extends SpecialPage {
 	function __construct() {
-		parent::__construct('Vote');
+		parent::__construct('Vote', 'vote');
 	}
 	
 	function handleVoteSubmission() {
@@ -111,6 +111,7 @@ class SpecialVote extends SpecialPage {
 	function execute($par) {
 		$request = $this->getRequest();
 		$this->getOutput()->setPageTitle('Vote');
+		$this->checkPermissions();
 		
 		if ($request->wasPosted()) {
 			$this->handleVoteSubmission();

--- a/src/SpecialVote.php
+++ b/src/SpecialVote.php
@@ -16,6 +16,11 @@ class SpecialVote extends SpecialPage {
 		}
 		
 		$votes = $request->getArray('candidateRank');
+		if (!is_array($votes)) {
+			// Most likely just clicked Vote without selecting anything
+			$output->addHTML('Please select the rank for each candidate.');
+			return;
+		}
 		$voteRepo = new ElectionVoteRepository(__METHOD__, $wgElectionId);
 		$message = $voteRepo->addVotes($this->getUser(), $votes);
 		


### PR DESCRIPTION
Fixes #6
Fixes #7 

Other fixes:

- New permission `vote` (so that we can assign it to Wikian) - can be reverted if we need to
- Actually enforce permissions on viewing results
- Close transaction on error
- Add titles
- Show message `There are no votes to display.` in ElectionResults
- Better validation for votes: no longer accepts null (which browser can send for empty votes), floats, integers with leading zeroes or exponential notations, no longer accepts votes for unknown candidates
- Error message changed to `Candidate ranks must be unique, and you must select the rank for each candidate` since it will also be displayed for missing selections
- Do not allow voting if the election is inactive
- Do not allow voting if database is read-only